### PR TITLE
Fix VirtualFree call to release memory correctly

### DIFF
--- a/Source/LightHook.h
+++ b/Source/LightHook.h
@@ -261,7 +261,7 @@ static void PlatformFree(void* address, const unsigned long long size)
     ExFreePool(address);
 #endif
 #else
-    VirtualFree(address, size, MEM_RELEASE);
+    VirtualFree(address, 0, MEM_RELEASE);
 #endif
 #ifdef __linux__
     munmap(address, size);


### PR DESCRIPTION
Hi, according to the Microsoft documentation for VirtualFree:
> If the dwFreeType parameter is MEM_RELEASE, this parameter must be 0 (zero). The function frees the entire region that is reserved in the initial allocation call to [VirtualAlloc](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc). 

When a non-zero size is provided, the memory is not released and this generates the compiler warning that irritates me.
Passing 0 resolves the issue and the memory is correctly freed.

Happy to revise if I’m overlooking anything.