### PR TITLE
Fix unreferenced variable warning

### DIFF
--- a/Source/LightHook.h
+++ b/Source/LightHook.h
@@ -261,6 +261,7 @@ static void PlatformFree(void* address, const unsigned long long size)
     ExFreePool(address);
 #endif
 #else
+	(void)size;
     VirtualFree(address, 0, MEM_RELEASE);
 #endif
 #ifdef __linux__


### PR DESCRIPTION
Regression from https://github.com/SamuelTulach/LightHook/pull/15